### PR TITLE
Potential fix for code scanning alert no. 7: Replacement of a substring with itself

### DIFF
--- a/src/js/terminal.js
+++ b/src/js/terminal.js
@@ -308,7 +308,7 @@ export class Terminal {
     if (file && file.startsWith('/')) {
       const trimmed = file.replace(/^\//, '');
       if (trimmed === 'about.md') return this.bundle.aboutMd;
-      const vPath = trimmed.replace(/^blog\//, 'blog/');
+      const vPath = trimmed;
       return this.bundle.postMarkdownByVirtualPath[vPath];
     }
     return undefined;


### PR DESCRIPTION
Potential fix for [https://github.com/Qu3b411/Qu3b411.tech/security/code-scanning/7](https://github.com/Qu3b411/Qu3b411.tech/security/code-scanning/7)

Remove the ineffective replacement and assign `trimmed` directly to `vPath`.

- General fix: when a `replace` operation substitutes a match with identical text, remove or correct it so the code expresses real intent.
- Best fix here (no functionality change): in `src/js/terminal.js` within `getMarkdownForFile`, change:
  - `const vPath = trimmed.replace(/^blog\//, 'blog/');`
  - to `const vPath = trimmed;`
- No imports, new methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
