### PR TITLE
Potential fix for code scanning alert no. 6: Replacement of a substring with itself

### DIFF
--- a/docs/assets/js/terminal.js
+++ b/docs/assets/js/terminal.js
@@ -308,7 +308,7 @@ export class Terminal {
     if (file && file.startsWith('/')) {
       const trimmed = file.replace(/^\//, '');
       if (trimmed === 'about.md') return this.bundle.aboutMd;
-      const vPath = trimmed.replace(/^blog\//, 'blog/');
+      const vPath = trimmed;
       return this.bundle.postMarkdownByVirtualPath[vPath];
     }
     return undefined;


### PR DESCRIPTION
Potential fix for [https://github.com/Qu3b411/Qu3b411.tech/security/code-scanning/6](https://github.com/Qu3b411/Qu3b411.tech/security/code-scanning/6)

The best fix is to remove the no-op replacement and use the already-trimmed path directly.

In `docs/assets/js/terminal.js`, inside `getMarkdownForFile(file)`, in the `if (file && file.startsWith('/')) { ... }` block, replace:

- `const vPath = trimmed.replace(/^blog\//, 'blog/');`

with:

- `const vPath = trimmed;`

This preserves current functionality (because the old expression always produced `trimmed`) while removing misleading code and resolving the CodeQL alert. No imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
