### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -6,6 +6,9 @@ on:
       - "master"
       - "pre-prod"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Qu3b411/Qu3b411.tech/security/code-scanning/3](https://github.com/Qu3b411/Qu3b411.tech/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root in `.github/workflows/test-docker-build.yml`, directly after the `on:` trigger section and before `jobs:`.  
For this workflow, the least-privilege baseline is:

- `contents: read` (needed for `actions/checkout` to read repository content)

No imports, methods, or external dependencies are needed. This change preserves behavior while constraining token scope and satisfying the CodeQL rule.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
