### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check_source_branch.yml
+++ b/.github/workflows/check_source_branch.yml
@@ -1,5 +1,7 @@
 name: Check Source Branch
 
+permissions: {}
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Qu3b411/Qu3b411.tech/security/code-scanning/2](https://github.com/Qu3b411/Qu3b411.tech/security/code-scanning/2)

Add an explicit `permissions` block to the workflow, using least privilege required for this job. Since the job only checks `github.head_ref` in a shell script and does not need write scopes, set:

- `permissions: {}` at workflow root (most restrictive), or
- minimally `contents: read`.

Best fix here without changing behavior: add a workflow-level `permissions: {}` directly under `name`/before `on`, so all jobs in this workflow inherit no token permissions unless later overridden. No imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
