### PR TITLE
Restore terminal green styling and single scrollbar

### DIFF
--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -12,6 +12,7 @@ body {
   background-position: center center;
   color: #cfcfcf;
   position: relative;
+  overflow-x: hidden;
 }
 
 #app-container {
@@ -109,6 +110,8 @@ header #postsDropdownContainer {
 #terminalSurface {
   position: relative;
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Both the terminal container and editor surface are absolutely positioned
@@ -120,6 +123,7 @@ header #postsDropdownContainer {
   inset: 0;
   width: 100%;
   height: 100%;
+  box-sizing: border-box;
 }
 
 /* By default the editor surface is hidden. When the terminal has
@@ -179,7 +183,17 @@ header #postsDropdownContainer {
 /* Make the xterm terminal fill its container */
 #term-container .xterm {
   flex: 1;
+  width: 100%;
+  min-width: 0;
   height: 100%;
+}
+
+#term-container .xterm-viewport {
+  /* xterm.css uses overflow-y: scroll, which shows a scrollbar even at the
+     initial prompt. Use auto so the terminal never shows a duplicate or
+     unnecessary scrollbar when there is no scrollback to display. */
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
 }
 
 @keyframes rgb-border {
@@ -295,6 +309,7 @@ header #postsDropdownContainer {
 /* Footer styling */
 footer#footer {
   width: 100%;
+  box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0.85);
   color: #cfcfcf;
   padding: 0.5rem 1rem;

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -79,11 +79,12 @@ header #postsDropdownContainer {
 /* Terminal styling */
 #terminal {
   /* Semi-transparent dark panel over the hacker space image */
-  --term-panel: rgba(0, 0, 0, 0.55);
-  --term-panel-weak: rgba(0, 0, 0, 0.745);
+  --terminal-green: #00ff00;
+  --term-panel: rgba(0, 0, 0, 0.85);
+  --term-panel-weak: rgba(0, 0, 0, 0.7);
 
   background-color: var(--term-panel);
-  backdrop-filter:blur(6px);
+  color: var(--terminal-green);
   border: 3px solid transparent;
   border-radius: 8px;
   overflow: hidden;
@@ -95,22 +96,11 @@ header #postsDropdownContainer {
   display: flex;
   flex-direction: column;
 }
-/* Make normal terminal view match editor panel */
-#term-container {
- 
-}
-
 /* xterm internals sometimes render on transparent layers */
 #term-container .xterm,
 #term-container .xterm-viewport,
 #term-container .xterm-screen {
   background: transparent !important; /* let container show through */
-}
-
-/* If you want the same padding feel as editor */
-#term-container {
-  padding: 0.5rem;
-  box-sizing: border-box;
 }
 
 /* The inner surface that holds both the xterm view and editor surfaces.
@@ -156,7 +146,7 @@ header #postsDropdownContainer {
   gap: 0.5rem;
   padding: 0.25rem 0.5rem;
   background-color: var(--term-panel-weak);
-border-bottom: 1px solid #444;
+  border-bottom: 1px solid #444;
 }
 
 .window-btn {
@@ -177,12 +167,11 @@ border-bottom: 1px solid #444;
 
 /* Container where xterm attaches */
 #term-container {
-  /* Take up the full viewport of the terminal surface. Positioning
-     will be set by the parent (#terminalSurface) so that xterm and
-     editor surfaces can swap in-place. */
+  /* xterm owns vertical scrolling via its viewport; keep this wrapper from
+     creating a second scrollbar inside the terminal window. */
   padding: 0.5rem;
-  overflow-y: auto;
-  overflow-x: hidden;
+  box-sizing: border-box;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
 }
@@ -227,6 +216,28 @@ border-bottom: 1px solid #444;
 
 /* View overlay styling */
 /* In-terminal editor surface styling */
+#editor-surface {
+  /* Fill the same terminal viewport without introducing an outer scrollbar;
+     the content pane below is the single scrolling region for editor modes. */
+  flex-direction: column;
+  overflow: hidden;
+  background-color: var(--term-panel);
+  color: var(--terminal-green);
+  padding: 0.5rem;
+  box-sizing: border-box;
+}
+
+#term-container .xterm,
+#term-container .xterm-viewport,
+#term-container .xterm-screen,
+#term-container .xterm-rows {
+  color: var(--terminal-green) !important;
+}
+
+#term-container .xterm-cursor-block {
+  background-color: var(--terminal-green) !important;
+  border-color: var(--terminal-green) !important;
+}
 
 /* Individual editor views within the editor surface */
 .editor-view {
@@ -238,6 +249,7 @@ border-bottom: 1px solid #444;
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
 }
 
 /* Header styling for editor modes */
@@ -257,7 +269,9 @@ border-bottom: 1px solid #444;
 .editor-view .view-content {
   white-space: pre-wrap;
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* Nano bottom command bar */
@@ -269,13 +283,13 @@ border-bottom: 1px solid #444;
   margin-top: 1rem;
   padding: 0.35rem 0.5rem;
   background-color: var(--term-panel-weak);
-border-top: 1px solid #444;
+  border-top: 1px solid #444;
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   justify-content: center;
   font-size: 0.75rem;
-  color: #cfcfcf;
+  color: var(--terminal-green);
 }
 
 /* Footer styling */

--- a/docs/assets/data/BUILD_MANIFEST.json
+++ b/docs/assets/data/BUILD_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "assets/css/site.css": "7c3a023363535f365dc3aa8779c62a5ca0a1e239481c7666988ca95183ad55e8",
+  "assets/css/site.css": "728bea8078058696d1e963c75294b6f830229deb63edb58cd60a8f685cb45eea",
   "assets/css/site.css.bak": "0c1501ecafe6d83a0d058541e3bd7b53b387ccaee1a9f45edb0fda350663aabd",
   "assets/css/terminal.css": "d450cc271df6ad3fcab995b8909e1a9ecc87e58542f59b3c245531f03e5f8549",
   "assets/data/SECURITY_NOTES.json": "c702e40d2ee39281a91e3c747187bfb260c41f21cebad7073d4aee9c0992c2b3",
@@ -14,9 +14,9 @@
   "assets/js/app.js": "cd38a4f4ce74fe066d6e597c6285e1241e1fb497ce6ac3f3563cf2ee4681e844",
   "assets/js/blog.js": "1a3d85a3386ed7d9a3439237d96ddc17ab02e72570202bdbeae69c408997c1b5",
   "assets/js/router.js": "b9dc4a6640d5ac5062a4a85267f1d7b538f5b4a86428b7af32670620edd0c2cd",
-  "assets/js/terminal.js": "09a184d332e506677c6e577f2155b489d071e0ffc7cbc2ec11d7f2f5f3d2a459",
+  "assets/js/terminal.js": "0d831e0a765dc2fdb105999dbae91c8fff063b01e62f82c7438ebf7959b5312f",
   "assets/xterm/.gitkeep": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "assets/xterm/xterm.css": "f6603a9878dafe03d016b84739755768758db482019efaf454a4486cd8171eba",
   "assets/xterm/xterm.js": "f0aea0f75f48559013ae6643c2479dd737d26da42d5524e6d2b70915ae6523c7",
-  "index.html": "3fbbeed7c96dca6725d173ffe96f85c8023426edd5c797012f59fd28710363c4"
+  "index.html": "8fe7620ab5f633379efb166af3222778f5ef8ce5faf28fd4cc79d539122a0382"
 }

--- a/docs/assets/data/BUILD_MANIFEST.json
+++ b/docs/assets/data/BUILD_MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "assets/css/site.css": "f9b28de985800efb7f4034e4850647edeb064d25e278c4a34a9418aa76d09768",
+  "assets/css/site.css": "7c3a023363535f365dc3aa8779c62a5ca0a1e239481c7666988ca95183ad55e8",
   "assets/css/site.css.bak": "0c1501ecafe6d83a0d058541e3bd7b53b387ccaee1a9f45edb0fda350663aabd",
   "assets/css/terminal.css": "d450cc271df6ad3fcab995b8909e1a9ecc87e58542f59b3c245531f03e5f8549",
   "assets/data/SECURITY_NOTES.json": "c702e40d2ee39281a91e3c747187bfb260c41f21cebad7073d4aee9c0992c2b3",
@@ -14,7 +14,7 @@
   "assets/js/app.js": "cd38a4f4ce74fe066d6e597c6285e1241e1fb497ce6ac3f3563cf2ee4681e844",
   "assets/js/blog.js": "1a3d85a3386ed7d9a3439237d96ddc17ab02e72570202bdbeae69c408997c1b5",
   "assets/js/router.js": "b9dc4a6640d5ac5062a4a85267f1d7b538f5b4a86428b7af32670620edd0c2cd",
-  "assets/js/terminal.js": "bc11e6f11a0c0e5048854fd6c1877e7dd10224bd24f18fd256c80f15da67bce6",
+  "assets/js/terminal.js": "09a184d332e506677c6e577f2155b489d071e0ffc7cbc2ec11d7f2f5f3d2a459",
   "assets/xterm/.gitkeep": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "assets/xterm/xterm.css": "f6603a9878dafe03d016b84739755768758db482019efaf454a4486cd8171eba",
   "assets/xterm/xterm.js": "f0aea0f75f48559013ae6643c2479dd737d26da42d5524e6d2b70915ae6523c7",

--- a/docs/assets/js/terminal.js
+++ b/docs/assets/js/terminal.js
@@ -38,6 +38,9 @@ export class Terminal {
       convertEol: true
     });
     this.term.open(this.containerEl);
+    // Keep rendered terminal glyphs green even if xterm falls back from themed
+    // canvas rendering to DOM-rendered rows.
+    this.term.write('\x1b[38;2;0;255;0m');
     // Focus the terminal on init so that user can start typing immediately
     if (typeof this.term.focus === 'function') {
       this.term.focus();

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; script-src 'self'; style-src 'self';" />
     <title>Terminal Blog</title>
+    <!-- Include xterm.js CSS first so local terminal styles can override defaults -->
+    <link rel="stylesheet" href="assets/xterm/xterm.css" />
     <!-- Main site CSS -->
     <link rel="stylesheet" href="assets/css/site.css" />
     <link rel="stylesheet" href="assets/css/terminal.css" />
-    <!-- Include xterm.js CSS for interactive terminal -->
-    <link rel="stylesheet" href="assets/xterm/xterm.css" />
   </head>
   <body>
     <!-- BEGIN BODY PLACEHOLDER -->

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -12,6 +12,7 @@ body {
   background-position: center center;
   color: #cfcfcf;
   position: relative;
+  overflow-x: hidden;
 }
 
 #app-container {
@@ -109,6 +110,8 @@ header #postsDropdownContainer {
 #terminalSurface {
   position: relative;
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
 }
 
 /* Both the terminal container and editor surface are absolutely positioned
@@ -120,6 +123,7 @@ header #postsDropdownContainer {
   inset: 0;
   width: 100%;
   height: 100%;
+  box-sizing: border-box;
 }
 
 /* By default the editor surface is hidden. When the terminal has
@@ -179,7 +183,17 @@ header #postsDropdownContainer {
 /* Make the xterm terminal fill its container */
 #term-container .xterm {
   flex: 1;
+  width: 100%;
+  min-width: 0;
   height: 100%;
+}
+
+#term-container .xterm-viewport {
+  /* xterm.css uses overflow-y: scroll, which shows a scrollbar even at the
+     initial prompt. Use auto so the terminal never shows a duplicate or
+     unnecessary scrollbar when there is no scrollback to display. */
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
 }
 
 @keyframes rgb-border {
@@ -295,6 +309,7 @@ header #postsDropdownContainer {
 /* Footer styling */
 footer#footer {
   width: 100%;
+  box-sizing: border-box;
   background-color: rgba(0, 0, 0, 0.85);
   color: #cfcfcf;
   padding: 0.5rem 1rem;

--- a/src/css/site.css
+++ b/src/css/site.css
@@ -79,11 +79,12 @@ header #postsDropdownContainer {
 /* Terminal styling */
 #terminal {
   /* Semi-transparent dark panel over the hacker space image */
-  --term-panel: rgba(0, 0, 0, 0.55);
-  --term-panel-weak: rgba(0, 0, 0, 0.745);
+  --terminal-green: #00ff00;
+  --term-panel: rgba(0, 0, 0, 0.85);
+  --term-panel-weak: rgba(0, 0, 0, 0.7);
 
   background-color: var(--term-panel);
-  backdrop-filter:blur(6px);
+  color: var(--terminal-green);
   border: 3px solid transparent;
   border-radius: 8px;
   overflow: hidden;
@@ -95,22 +96,11 @@ header #postsDropdownContainer {
   display: flex;
   flex-direction: column;
 }
-/* Make normal terminal view match editor panel */
-#term-container {
- 
-}
-
 /* xterm internals sometimes render on transparent layers */
 #term-container .xterm,
 #term-container .xterm-viewport,
 #term-container .xterm-screen {
   background: transparent !important; /* let container show through */
-}
-
-/* If you want the same padding feel as editor */
-#term-container {
-  padding: 0.5rem;
-  box-sizing: border-box;
 }
 
 /* The inner surface that holds both the xterm view and editor surfaces.
@@ -156,7 +146,7 @@ header #postsDropdownContainer {
   gap: 0.5rem;
   padding: 0.25rem 0.5rem;
   background-color: var(--term-panel-weak);
-border-bottom: 1px solid #444;
+  border-bottom: 1px solid #444;
 }
 
 .window-btn {
@@ -177,12 +167,11 @@ border-bottom: 1px solid #444;
 
 /* Container where xterm attaches */
 #term-container {
-  /* Take up the full viewport of the terminal surface. Positioning
-     will be set by the parent (#terminalSurface) so that xterm and
-     editor surfaces can swap in-place. */
+  /* xterm owns vertical scrolling via its viewport; keep this wrapper from
+     creating a second scrollbar inside the terminal window. */
   padding: 0.5rem;
-  overflow-y: auto;
-  overflow-x: hidden;
+  box-sizing: border-box;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
 }
@@ -227,6 +216,28 @@ border-bottom: 1px solid #444;
 
 /* View overlay styling */
 /* In-terminal editor surface styling */
+#editor-surface {
+  /* Fill the same terminal viewport without introducing an outer scrollbar;
+     the content pane below is the single scrolling region for editor modes. */
+  flex-direction: column;
+  overflow: hidden;
+  background-color: var(--term-panel);
+  color: var(--terminal-green);
+  padding: 0.5rem;
+  box-sizing: border-box;
+}
+
+#term-container .xterm,
+#term-container .xterm-viewport,
+#term-container .xterm-screen,
+#term-container .xterm-rows {
+  color: var(--terminal-green) !important;
+}
+
+#term-container .xterm-cursor-block {
+  background-color: var(--terminal-green) !important;
+  border-color: var(--terminal-green) !important;
+}
 
 /* Individual editor views within the editor surface */
 .editor-view {
@@ -238,6 +249,7 @@ border-bottom: 1px solid #444;
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-height: 0;
 }
 
 /* Header styling for editor modes */
@@ -257,7 +269,9 @@ border-bottom: 1px solid #444;
 .editor-view .view-content {
   white-space: pre-wrap;
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* Nano bottom command bar */
@@ -269,13 +283,13 @@ border-bottom: 1px solid #444;
   margin-top: 1rem;
   padding: 0.35rem 0.5rem;
   background-color: var(--term-panel-weak);
-border-top: 1px solid #444;
+  border-top: 1px solid #444;
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
   justify-content: center;
   font-size: 0.75rem;
-  color: #cfcfcf;
+  color: var(--terminal-green);
 }
 
 /* Footer styling */

--- a/src/js/terminal.js
+++ b/src/js/terminal.js
@@ -38,6 +38,9 @@ export class Terminal {
       convertEol: true
     });
     this.term.open(this.containerEl);
+    // Keep rendered terminal glyphs green even if xterm falls back from themed
+    // canvas rendering to DOM-rendered rows.
+    this.term.write('\x1b[38;2;0;255;0m');
     // Focus the terminal on init so that user can start typing immediately
     if (typeof this.term.focus === 'function') {
       this.term.focus();

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data:; script-src 'self'; style-src 'self';" />
     <title>Terminal Blog</title>
+    <!-- Include xterm.js CSS first so local terminal styles can override defaults -->
+    <link rel="stylesheet" href="assets/xterm/xterm.css" />
     <!-- Main site CSS -->
     <link rel="stylesheet" href="assets/css/site.css" />
     <link rel="stylesheet" href="assets/css/terminal.css" />
-    <!-- Include xterm.js CSS for interactive terminal -->
-    <link rel="stylesheet" href="assets/xterm/xterm.css" />
   </head>
   <body>
     <!-- BEGIN BODY PLACEHOLDER -->


### PR DESCRIPTION
### Motivation
- A prior change altered the terminal appearance and introduced nested scrollbars; the intent here is to restore the classic green-on-dark terminal text and ensure only a single vertical scrollbar is present inside the terminal viewport.

### Description
- Reintroduced a terminal color variable `--terminal-green` and applied it to the terminal panel and xterm elements so foreground and cursor remain green (changes in `src/css/site.css`).
- Prevented a second scrollbar by making the term wrapper non-scrollable (`overflow: hidden`) and moving scrolling to the xterm/editor content panes, and added an `#editor-surface` rule that also avoids creating an outer scrollbar (`src/css/site.css`).
- Adjusted editor layout rules (`.editor-view` and `.view-content`) to use `min-height: 0` and constrained horizontal overflow so editor modes do not produce an extra scroll region (`src/css/site.css`).
- Rebuilt the static site so the `docs` output and `docs/assets/data/BUILD_MANIFEST.json` include the updated CSS (`node build/build.js`).

### Testing
- Ran `node build/build.js` to regenerate `docs` and the manifest, which completed successfully.
- Ran an automated assertion script (`node - <<'NODE' ... NODE`) that validated presence of `--terminal-green`, `color: var(--terminal-green)`, `cursorBlink: true` in the bundled JS, and that the term wrapper and editor surface use `overflow: hidden;`, and the script passed.
- Ran `git diff --check` which reported no whitespace/diff issues.
- Attempted an end-to-end screenshot with Playwright, but the Playwright install failed due to the environment npm registry returning `403 Forbidden` (so screenshot capture did not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a187d4168808331be9d247e65811b73)